### PR TITLE
Expired items replacement feature v1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <source>9</source>
+                    <target>9</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,10 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
+        <repository>
+            <id>aikar</id>
+            <url>https://repo.aikar.co/content/groups/aikar/</url>
+        </repository>
     </repositories>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -118,13 +118,13 @@
         <dependency>
             <groupId>com.github.anhcraft.config</groupId>
             <artifactId>config.bukkit</artifactId>
-            <version>v1.1.7</version>
+            <version>v1.2.5</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.github.anhcraft.config</groupId>
             <artifactId>config.configdoc</artifactId>
-            <version>v1.1.7</version>
+            <version>v1.2.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/dev/anhcraft/timedmmoitems/TimedMMOItems.java
+++ b/src/main/java/dev/anhcraft/timedmmoitems/TimedMMOItems.java
@@ -31,6 +31,7 @@ public final class TimedMMOItems extends JavaPlugin {
     public Config config;
     public SimpleDateFormat dateFormat;
 
+
     @Override
     public void onEnable() {
         plugin = this;

--- a/src/main/java/dev/anhcraft/timedmmoitems/config/Config.java
+++ b/src/main/java/dev/anhcraft/timedmmoitems/config/Config.java
@@ -4,6 +4,8 @@ import dev.anhcraft.config.annotations.Configurable;
 import dev.anhcraft.config.annotations.Description;
 import dev.anhcraft.config.annotations.Validation;
 
+import java.util.*;
+
 @Configurable(keyNamingStyle = Configurable.NamingStyle.TRAIN_CASE)
 public class Config {
     @Description("Expiry period stat format")
@@ -14,11 +16,11 @@ public class Config {
     @Validation(notNull = true, silent = true)
     public String expiryDateFormat = "&e[Expiry Date: %value%]";
 
-    @Description("Item expired message")
+    @Description("ItemConfig expired message")
     @Validation(notNull = true, silent = true)
-    public String itemExpired = "&c&l[!] Item is expired";
+    public String itemExpired = "&c&l[!] ItemConfig is expired";
 
-    @Description("Item expired message placement")
+    @Description("ItemConfig expired message placement")
     @Validation(notNull = true, silent = true)
     public String itemExpiredPlacement = "action-bar";
 
@@ -29,11 +31,15 @@ public class Config {
     @Validation(notNull = true, silent = true)
     public String expiredItemRemoved = "&cRemoved %amount% expired items";
 
+    @Description("Replaced item dropped on the ground message")
+    @Validation(notNull = true, silent = true)
+    public String replacedItemDropped = "&c[!] Some items were dropped on the ground";
+
     @Description("Unit format")
     @Validation(notNull = true, silent = true)
     public UnitConfig unitFormat = new UnitConfig();
 
-    @Description("Item check interval in seconds")
+    @Description("ItemConfig check interval in seconds")
     public int itemCheckInterval = 5;
 
     @Description("Replace expiry period with expiry date instead of keeping both stats")
@@ -45,4 +51,12 @@ public class Config {
 
     @Description("Inventory update is usually handled automatically. Enable this if you experience glitch!")
     public boolean forceUpdateInventory = false;
+
+    @Description("Expired item change")
+    @Validation(notNull = true, silent = true)
+    public Map<String, List<ItemConfig>> expiredItemReplace = new HashMap<>() {{
+        put("DRAGON_HELMET", Arrays.asList(new ItemConfig("bukkit", "stone", 2), new ItemConfig("bukkit", "egg", 128)));
+        put("DRAGON_CHESTPLATE", Arrays.asList(new ItemConfig("bukkit", "oak_log", 2), new ItemConfig("ARMOR", "STEEL_CHESTPLATE", 1)));
+        put("DRAGON_LEGGINGS", Arrays.asList(new ItemConfig("bukkit", "gold_blog", 1), new ItemConfig("armor", "STEEL_LEGGINGS", 1)));
+    }};
 }

--- a/src/main/java/dev/anhcraft/timedmmoitems/config/Config.java
+++ b/src/main/java/dev/anhcraft/timedmmoitems/config/Config.java
@@ -16,7 +16,7 @@ public class Config {
     @Validation(notNull = true, silent = true)
     public String expiryDateFormat = "&e[Expiry Date: %value%]";
 
-    @Description("Itemexpired message")
+    @Description("Item expired message")
     @Validation(notNull = true, silent = true)
     public String itemExpired = "&c&l[!] Item is expired";
 

--- a/src/main/java/dev/anhcraft/timedmmoitems/config/Config.java
+++ b/src/main/java/dev/anhcraft/timedmmoitems/config/Config.java
@@ -16,11 +16,11 @@ public class Config {
     @Validation(notNull = true, silent = true)
     public String expiryDateFormat = "&e[Expiry Date: %value%]";
 
-    @Description("ItemConfig expired message")
+    @Description("Itemexpired message")
     @Validation(notNull = true, silent = true)
-    public String itemExpired = "&c&l[!] ItemConfig is expired";
+    public String itemExpired = "&c&l[!] Item is expired";
 
-    @Description("ItemConfig expired message placement")
+    @Description("Item expired message placement")
     @Validation(notNull = true, silent = true)
     public String itemExpiredPlacement = "action-bar";
 
@@ -39,7 +39,7 @@ public class Config {
     @Validation(notNull = true, silent = true)
     public UnitConfig unitFormat = new UnitConfig();
 
-    @Description("ItemConfig check interval in seconds")
+    @Description("Item check interval in seconds")
     public int itemCheckInterval = 5;
 
     @Description("Replace expiry period with expiry date instead of keeping both stats")

--- a/src/main/java/dev/anhcraft/timedmmoitems/config/ItemConfig.java
+++ b/src/main/java/dev/anhcraft/timedmmoitems/config/ItemConfig.java
@@ -1,0 +1,28 @@
+package dev.anhcraft.timedmmoitems.config;
+
+import dev.anhcraft.config.annotations.Configurable;
+import dev.anhcraft.config.annotations.Validation;
+
+@Configurable(keyNamingStyle = Configurable.NamingStyle.TRAIN_CASE)
+public class ItemConfig {
+    @Validation(notNull = true, silent = true)
+    public String type = "bukkit";
+    @Validation(notNull = true, silent = true)
+    public String id = "air";
+    @Validation(notEmpty = true, silent = true)
+    public int amount = 1;
+
+    public ItemConfig() {
+    }
+
+    public ItemConfig(String type, String id, int amount) {
+        this.type = type;
+        this.id = id;
+        this.amount = amount;
+    }
+
+    @Override
+    public String toString() {
+        return "ItemConfig{type='" + type + "', material='" + id + "', amount=" + amount + "}";
+    }
+}

--- a/src/main/java/dev/anhcraft/timedmmoitems/task/CheckTask.java
+++ b/src/main/java/dev/anhcraft/timedmmoitems/task/CheckTask.java
@@ -1,6 +1,7 @@
 package dev.anhcraft.timedmmoitems.task;
 
 import dev.anhcraft.timedmmoitems.TimedMMOItems;
+import dev.anhcraft.timedmmoitems.config.ItemConfig;
 import io.lumine.mythic.lib.api.item.NBTItem;
 import net.Indyuce.mmoitems.api.item.mmoitem.LiveMMOItem;
 import net.Indyuce.mmoitems.stat.data.DoubleData;
@@ -10,8 +11,10 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import static dev.anhcraft.timedmmoitems.TimedMMOItems.EXPIRY_DATE;
 import static dev.anhcraft.timedmmoitems.TimedMMOItems.EXPIRY_PERIOD;
@@ -32,6 +35,11 @@ public class CheckTask extends BukkitRunnable {
 
             boolean needUpdate = false;
             int rmvCounter = 0;
+
+            boolean needReplace = false;
+            int rplCounter = 0;
+            HashMap<String, Integer> rplMap = new HashMap<>();
+
             List<ItemStack> newItems = new LinkedList<>();
 
             for (ItemStack item : player.getInventory().getContents()) {
@@ -49,6 +57,11 @@ public class CheckTask extends BukkitRunnable {
                     if (plugin.config.removeExpiredItem && mmo.hasData(EXPIRY_DATE) && ((DoubleData) mmo.getData(EXPIRY_DATE)).getValue() < System.currentTimeMillis()) {
                         rmvCounter += item.getAmount();
                         needUpdate = true;
+                        if (plugin.config.expiredItemReplace.containsKey(mmo.getId())) {
+                            rplCounter += item.getAmount();
+                            rplMap.put(mmo.getId(), rplCounter);
+                            needReplace = true;
+                        }
                         continue;
                     }
                 }
@@ -61,9 +74,35 @@ public class CheckTask extends BukkitRunnable {
             if (plugin.config.forceUpdateInventory) player.updateInventory();
 
             if (rmvCounter > 0) {
+                if (needReplace) itemReplace(player, rplMap);
                 String msg = plugin.config.expiredItemRemoved.replace("%amount%", Integer.toString(rmvCounter));
                 player.sendMessage(ChatColor.translateAlternateColorCodes('&', msg));
                 player.playSound(player.getLocation(), Sound.ENTITY_ITEM_BREAK, 1.0f, 1.0f);
+            }
+        }
+    }
+    private void itemReplace(Player player, HashMap<String, Integer> map) {
+        for (Map.Entry<String, Integer> entry : map.entrySet()) {
+            String itemId = entry.getKey();
+            int rplCounter = entry.getValue();
+            List<ItemConfig> itemConfigList = plugin.config.expiredItemReplace.get(itemId);
+
+            for (ItemConfig itemConfig : itemConfigList) {
+                try {
+                    ItemStack itemStack = ReplaceFactory.createItemStack(itemConfig, rplCounter);
+                    // Attempt to add to inventory
+                    HashMap<Integer, ItemStack> leftovers = player.getInventory().addItem(itemStack);
+                    if (!leftovers.isEmpty()) {
+                        // Drop leftovers on the ground
+                        for (ItemStack leftover : leftovers.values()) {
+                            player.getWorld().dropItem(player.getLocation(), leftover);
+                        }
+                        String msg = plugin.config.replacedItemDropped;
+                        player.sendMessage(ChatColor.translateAlternateColorCodes('&', msg));
+                    }
+                } catch (IllegalArgumentException e) {
+                    plugin.getLogger().severe(e.getMessage());
+                }
             }
         }
     }

--- a/src/main/java/dev/anhcraft/timedmmoitems/task/ReplaceFactory.java
+++ b/src/main/java/dev/anhcraft/timedmmoitems/task/ReplaceFactory.java
@@ -1,0 +1,34 @@
+package dev.anhcraft.timedmmoitems.task;
+
+import dev.anhcraft.timedmmoitems.config.ItemConfig;
+import net.Indyuce.mmoitems.MMOItems;
+import net.Indyuce.mmoitems.api.item.mmoitem.MMOItem;
+import net.Indyuce.mmoitems.manager.ItemManager;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+public class ReplaceFactory {
+    private ReplaceFactory() {}
+
+    public static ItemStack createItemStack(ItemConfig itemConfig, int multiplier) {
+        if (itemConfig.type.equalsIgnoreCase("bukkit")) {
+            Material material = Material.matchMaterial(itemConfig.id.toUpperCase());
+            if (material == null) {
+                throw new IllegalArgumentException("Could not replace expired item. Invalid Bukkit material: minecraft:" + itemConfig.id.toLowerCase());
+            }
+            return new ItemStack(material, itemConfig.amount * multiplier);
+        } else { // MMOItem
+            ItemManager itemManager = MMOItems.plugin.getItems();
+            MMOItem mmoitem = itemManager.getMMOItem(MMOItems.plugin.getTypes().get(itemConfig.type), itemConfig.id);
+
+            if (mmoitem != null) {
+                ItemStack itemStack = mmoitem.newBuilder().build();
+                itemStack.setAmount(itemConfig.amount * multiplier);
+                return itemStack;
+            } else {
+                throw new IllegalArgumentException(String.format("Couldn't replace expired item. %s:%s not found. Item TYPE and ID are case sensitive!",
+                        itemConfig.type, itemConfig.id));
+            }
+        }
+    }
+}


### PR DESCRIPTION
1) You can replace specific expired items with bukkit and\or custom items, multiple or not. 
2) All non-specific expired items will expire as usual - disappear or become non-interactive.
3) If player's inventory is full, all remaining items will drop on the ground. That's why there are new message string for.
4) There are designated console error messages if wrong bukkit\mi names specified in config. Incorrectly configured items will have default expiration logic.

**known issues:**
1)  **public Map<String, List<ItemConfig>> expiredItemReplace** filled with data correctly only on new config file creation (when config.yml not exist yet). If config exist, Map will have null entryList (as I told earlier). Even if it's same default config, that was generated by plugin itself.
HashMap creation need to be changed.
2) tmi reload command will not update any config values. (old bug) 